### PR TITLE
Add list categories and fix jsdoc in utils/plugins.js

### DIFF
--- a/plugins/channel.js
+++ b/plugins/channel.js
@@ -24,7 +24,6 @@ function op(bot, event, irc, args) {
 }
 op.opts = {
     perms: [false, true, false],
-    hide: false,
     min_args: 0,
     category: 'channel'
 };
@@ -35,7 +34,6 @@ function deop(bot, event, irc, args) {
 }
 deop.opts = {
     perms: [false, true, false],
-    hide: false,
     min_args: 0,
     category: 'channel'
 };

--- a/plugins/channel.js
+++ b/plugins/channel.js
@@ -25,7 +25,8 @@ function op(bot, event, irc, args) {
 op.opts = {
     perms: [false, true, false],
     hide: false,
-    min_args: 0
+    min_args: 0,
+    category: 'channel'
 };
 function deop(bot, event, irc, args) {
     let [target, nick] = _get_info(event, args);
@@ -35,7 +36,8 @@ function deop(bot, event, irc, args) {
 deop.opts = {
     perms: [false, true, false],
     hide: false,
-    min_args: 0
+    min_args: 0,
+    category: 'channel'
 };
 
 module.exports = {

--- a/plugins/general.js
+++ b/plugins/general.js
@@ -32,7 +32,7 @@ function todo(bot, event, irc, args) {
 todo.opts = {
     perms: [false, false, false],
     hide: false,
-    min_args: 0
+    min_args: 0,
 };
 
 function ping(bot, event, irc, args) {
@@ -83,11 +83,20 @@ function Eval(bot, event, irc, args) {
 }
 
 function list(bot, event, irc, args) {
-    irc.reply(event, Object.keys(bot.plugins.plugins).filter(x => {
-        if (x !== 'bot') {
-            return !bot.plugins.plugins[x].opts.hide;
-        }
-    }).join(', '));
+    if (args.length === 0) {
+        // TODO use colours util to create bolded text
+        irc.reply(event, '\x02Categories: \x0f' + bot.plugins.categories.join(', '));
+    } else {
+        irc.reply(event, '\x02Commands in ' + args[0].replace(/\W/g, '')
+            + ': \x0f'
+            + Object.keys(bot.plugins.plugins).filter(x => {
+                let is_right_category = bot.plugins.plugins[x].opts.category.toLowerCase() === args[0];
+                if (x !== 'bot') {
+                    return !bot.plugins.plugins[x].opts.hide && is_right_category;
+                }
+                return is_right_category;
+            }).join(', '));
+    }
 }
 
 list.opts = {

--- a/plugins/general.js
+++ b/plugins/general.js
@@ -33,6 +33,7 @@ todo.opts = {
     perms: [false, false, false],
     hide: false,
     min_args: 0,
+    category: 'general'
 };
 
 function ping(bot, event, irc, args) {
@@ -42,7 +43,8 @@ function ping(bot, event, irc, args) {
 ping.opts = {
     perms: [false, false, false],
     min_args: 0,
-    hide: false
+    hide: false,
+    category: 'general'
 };
 
 function join(bot, event, irc, args) {
@@ -51,7 +53,8 @@ function join(bot, event, irc, args) {
 join.opts = {
     perms: [false, true, true],
     min_args: 1,
-    hide: false
+    hide: false,
+    category: 'general'
 };
 
 
@@ -62,7 +65,8 @@ function quit(bot, event, irc, args) {
 quit.opts = {
     perms: [false, true, true],
     min_args: 0,
-    hide: false
+    hide: false,
+    category: 'general'
 };
 
 function Eval(bot, event, irc, args) {
@@ -102,13 +106,15 @@ function list(bot, event, irc, args) {
 list.opts = {
     perms: [false, false, false],
     min_args: 0,
-    hide: false
+    hide: false,
+    category: 'general'
 };
 
 Eval.opts = {
     perms: [false, false, true],
     min_args: 1,
-    hide: false
+    hide: false,
+    category: 'general'
 };
 
 module.exports = {

--- a/plugins/general.js
+++ b/plugins/general.js
@@ -30,8 +30,6 @@ function todo(bot, event, irc, args) {
 }
 
 todo.opts = {
-    perms: [false, false, false],
-    hide: false,
     min_args: 0,
     category: 'general'
 };
@@ -41,9 +39,7 @@ function ping(bot, event, irc, args) {
 }
 
 ping.opts = {
-    perms: [false, false, false],
     min_args: 0,
-    hide: false,
     category: 'general'
 };
 
@@ -53,7 +49,6 @@ function join(bot, event, irc, args) {
 join.opts = {
     perms: [false, true, true],
     min_args: 1,
-    hide: false,
     category: 'general'
 };
 
@@ -65,7 +60,6 @@ function quit(bot, event, irc, args) {
 quit.opts = {
     perms: [false, true, true],
     min_args: 0,
-    hide: false,
     category: 'general'
 };
 
@@ -104,16 +98,13 @@ function list(bot, event, irc, args) {
 }
 
 list.opts = {
-    perms: [false, false, false],
     min_args: 0,
-    hide: false,
     category: 'general'
 };
 
 Eval.opts = {
     perms: [false, false, true],
     min_args: 1,
-    hide: false,
     category: 'general'
 };
 


### PR DESCRIPTION
Added missing jsdoc in utils/plugins.js in class Hooks

List now supports categories. For example, 
`.list` will output 

**Categories:** channel, general

`.list general` might output

**Commands in general:** todo, ping, quit, eval, list, join